### PR TITLE
Fix specs with Ruby 2.0, clean up use of deprecated RSpec features.

### DIFF
--- a/spec/lib/chatter/feed_item_spec.rb
+++ b/spec/lib/chatter/feed_item_spec.rb
@@ -28,7 +28,7 @@ describe Databasedotcom::Chatter::FeedItem do
       it "likes the feed item" do
         body = JSON.parse(File.read(File.join(File.dirname(__FILE__), "../../fixtures/chatter/likes_get_id_success_response.json")))
         @response = double("response")
-        @response.should_receive(:body).any_number_of_times.and_return(body)
+        @response.should_receive(:body).at_least(:once).and_return(body)
         @client_mock.should_receive(:http_post).with("/services/data/v23/chatter/feed-items/#{@record.id}/likes").and_return(@response)
         like = @record.like
         like.should be_instance_of(Databasedotcom::Chatter::Like)
@@ -39,7 +39,7 @@ describe Databasedotcom::Chatter::FeedItem do
       it "comments on the feed item" do
         body = JSON.parse(File.read(File.join(File.dirname(__FILE__), "../../fixtures/chatter/comments_get_id_success_response.json")))
         @response = double("response")
-        @response.should_receive(:body).any_number_of_times.and_return(body)
+        @response.should_receive(:body).at_least(:once).and_return(body)
         @client_mock.should_receive(:http_post).with("/services/data/v23/chatter/feed-items/#{@record.id}/comments", nil, :text => "whatever").and_return(@response)
         comment = @record.comment("whatever")
         comment.should be_instance_of(Databasedotcom::Chatter::Comment)

--- a/spec/lib/shared_behaviors/restful_resource.rb
+++ b/spec/lib/shared_behaviors/restful_resource.rb
@@ -19,7 +19,7 @@ shared_examples_for("a restful resource") do
         body = File.read(File.join(File.dirname(__FILE__), "../../fixtures/chatter/#{described_class.resource_name}_get_id_success_response.json"))
         @client_mock = double("client", :version => "23")
         @response = double("response")
-        @response.should_receive(:body).any_number_of_times.and_return(body)
+        @response.should_receive(:body).at_least(:once).and_return(body)
       end
 
       it "gets a resource by id" do
@@ -48,7 +48,7 @@ shared_examples_for("a restful resource") do
             body = File.read(File.join(File.dirname(__FILE__), "../../fixtures/chatter/#{described_class.resource_name}_batch_get_success_response.json"))
             @client_mock = double("client", :version => "23")
             @response = double("response")
-            @response.should_receive(:body).any_number_of_times.and_return(body)
+            @response.should_receive(:body).at_least(:once).and_return(body)
           end
 
           it "gets all the resources" do
@@ -66,7 +66,7 @@ shared_examples_for("a restful resource") do
             body = File.read(File.join(File.dirname(__FILE__), "../../fixtures/chatter/#{described_class.resource_name}_batch_get_mixed_response.json"))
             @client_mock = double("client", :version => "23")
             @response = double("response")
-            @response.should_receive(:body).any_number_of_times.and_return(body)
+            @response.should_receive(:body).at_least(:once).and_return(body)
           end
 
           it "gets all the users" do
@@ -86,7 +86,7 @@ shared_examples_for("a restful resource") do
         body = File.read(File.join(File.dirname(__FILE__), "../../fixtures/chatter/#{described_class.resource_name}_get_success_response.json"))
         @client_mock = double("client", :version => "23")
         @response = double("response")
-        @response.should_receive(:body).any_number_of_times.and_return(body)
+        @response.should_receive(:body).at_least(:once).and_return(body)
       end
 
       it "gets a collection of resources" do

--- a/spec/lib/sobject/sobject_spec.rb
+++ b/spec/lib/sobject/sobject_spec.rb
@@ -116,7 +116,7 @@ describe Databasedotcom::Sobject::Sobject do
       context "when the objects are different classes" do
 
         before do
-          @second = stub(:is_a? => false)
+          @second = double(:is_a? => false)
         end
 
         it "returns false" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'webmock/rspec'
 Encoding.default_external = Encoding::UTF_8 if defined?(Encoding)
-Dir.glob(File.join(File.dirname(__FILE__), 'lib', 'shared_behaviors', '**', '.', '*.rb')).each do |f|
+Dir.glob(File.join(File.dirname(__FILE__), 'lib', 'shared_behaviors', '**', '*.rb')).each do |f|
     require f
 end


### PR DESCRIPTION
Spec fix for Ruby 2.0 (fixing require paths in spec_helper.rb) comes from upstream at https://github.com/heroku/databasedotcom/commit/f402a0d57d6d3223e2fff5f1ebd96a8842ec804c.

Cleanup of deprecated RSpec features from me, because it was hard to tell if the specs were actually running fine or not with all the deprecation noise.
